### PR TITLE
Updating building from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,5 @@ Want to contribute to Mu?  Awesome!  Check out the [contributing guidelines](CON
 * Install [Glide](https://github.com/Masterminds/glide) via `curl https://glide.sh/get | sh`
 * Clone this repo `git clone git@github.com:stelligent/mu.git $GOPATH/src/github.com/stelligent/mu`
 * Go to src `cd $GOPATH/src/github.com/stelligent/mu`
+* Ensure [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) is configured with an access key, secret access key, and region.
 * Build with `make`


### PR DESCRIPTION
Current README assumes AWS CLI is configured. Tests failed on a fresh machine. After running `aws configure` the tests pass.