### PR TITLE
Default service name to git repo name

### DIFF
--- a/common/context.go
+++ b/common/context.go
@@ -44,8 +44,6 @@ func (ctx *Context) InitializeConfigFromFile(muFile string) error {
 	log.Debugf("Setting basedir=%s", ctx.Config.Basedir)
 
 	ctx.Config.Repo.Name = path.Base(ctx.Config.Basedir)
-	log.Debugf("Setting repo name=%s", ctx.Config.Repo.Name)
-
 	ctx.Config.Repo.Revision = time.Now().Format("20060102150405")
 
 	// Get the git revision from the .git folder
@@ -64,17 +62,19 @@ func (ctx *Context) InitializeConfigFromFile(muFile string) error {
 			// See if the build was initiated by CodePipeline
 			if parts[0] == "codepipeline" {
 				// Try retrieving the revision from the CodePipeline status
-				gitRevision, err := ctx.PipelineManager.GetCurrentRevision(parts[1])
+				gitInfo, err := ctx.PipelineManager.GetGitInfo(parts[1])
 				if err != nil {
-					log.Warningf("Unable to determine git revision from CodeBuild initiator: %s", initiator)
+					log.Warningf("Unable to determine git information from CodeBuild initiator: %s", initiator)
 				}
 
-				ctx.Config.Repo.Revision = string(gitRevision[:7])
+				ctx.Config.Repo.Revision = string(gitInfo.revision[:7])
+				ctx.Config.Repo.Name = gitInfo.repoName
 			} else {
 				log.Warningf("Unable to process CodeBuild initiator: %s", initiator)
 			}
 		}
 	}
+	log.Debugf("Setting repo name=%s", ctx.Config.Repo.Name)
 	log.Debugf("Setting repo revision=%s", ctx.Config.Repo.Revision)
 
 	gitProvider, gitSlug, err := findGitSlug(ctx.Config.Basedir)

--- a/common/pipeline_test.go
+++ b/common/pipeline_test.go
@@ -40,7 +40,7 @@ func TestCodePipelineManager_ListState(t *testing.T) {
 	m.AssertNumberOfCalls(t, "GetPipelineState", 1)
 }
 
-func TestCodePipelineManager_GetCurrentRevision(t *testing.T) {
+func TestCodePipelineManager_GetGetInfo(t *testing.T) {
 	assert := assert.New(t)
 
 	m := new(mockedCPL)
@@ -71,7 +71,8 @@ func TestCodePipelineManager_GetCurrentRevision(t *testing.T) {
 		codePipelineAPI: m,
 	}
 
-	revision, err := pipelineManager.GetCurrentRevision("foo")
+	gitInfo, err := pipelineManager.GetGitInfo("foo")
 	assert.Nil(err)
-	assert.Equal("4e934a1e51476d88d715f421ecd86d93dad02c5b", revision)
+	assert.Equal("4e934a1e51476d88d715f421ecd86d93dad02c5b", gitInfo.revision)
+	assert.Equal("aftp-mu", gitInfo.repoName)
 }


### PR DESCRIPTION
Prevent CodePipeline from using 'src' as name
Fixes #112