### PR TITLE
Support for extra user data script

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -78,6 +78,7 @@ type Environment struct {
 		TargetCPUReservation    int    `yaml:"targetCPUReservation,omitempty"`
 		TargetMemoryReservation int    `yaml:"targetMemoryReservation,omitempty"`
 		HTTPProxy               string `yaml:"httpProxy,omitempty"`
+		ExtraUserData           string `yaml:"extraUserData,omitempty"`
 	} `yaml:"cluster,omitempty"`
 	Discovery struct {
 		Provider      string            `yaml:"provider,omitempty"`

--- a/templates/assets/env-ecs.yml
+++ b/templates/assets/env-ecs.yml
@@ -83,6 +83,10 @@ Parameters:
     AllowedValues:
     - EC2
     - FARGATE
+  ExtraUserData:
+    Type: String
+    Description: Additional user data script
+    Default: ''
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -400,6 +404,8 @@ Resources:
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ContainerInstances --configsets ${ImageOsType} --region ${AWS::Region} $CFN_PROXY_ARGS
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource EcsAutoScalingGroup --region ${AWS::Region} $CFN_PROXY_ARGS
 
+          ${ExtraUserData}
+
           --==BOUNDARY==
           Content-Type: text/text/upstart-job; charset="us-ascii"
 
@@ -421,6 +427,7 @@ Resources:
             instance_arn=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .ContainerInstanceArn' | awk -F/ '{print $NF}' )
             aws ecs start-task --cluster ${EcsCluster} --task-definition ${AWS::StackName}-consul-agent --container-instances $instance_arn --started-by $instance_arn --region ${AWS::Region}
           end script
+
           --==BOUNDARY==--
   ClusterLogGroup:
     Condition: HasLaunchTypeEC2

--- a/templates/assets/env-ecs.yml
+++ b/templates/assets/env-ecs.yml
@@ -399,12 +399,11 @@ Resources:
             CFN_PROXY_ARGS="--http-proxy http://${HttpProxy} --https-proxy http://${HttpProxy}"
           fi
 
+          ${ExtraUserData}
 
           yum install -y aws-cfn-bootstrap
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ContainerInstances --configsets ${ImageOsType} --region ${AWS::Region} $CFN_PROXY_ARGS
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource EcsAutoScalingGroup --region ${AWS::Region} $CFN_PROXY_ARGS
-
-          ${ExtraUserData}
 
           --==BOUNDARY==
           Content-Type: text/text/upstart-job; charset="us-ascii"

--- a/workflows/environment_upsert.go
+++ b/workflows/environment_upsert.go
@@ -311,6 +311,9 @@ func (workflow *environmentWorkflow) environmentUpserter(namespace string, ecsSt
 		if environment.Cluster.InstanceType != "" {
 			stackParams["InstanceType"] = environment.Cluster.InstanceType
 		}
+		if environment.Cluster.ExtraUserData != "" {
+			stackParams["ExtraUserData"] = environment.Cluster.ExtraUserData
+		}
 		if environment.Cluster.ImageID != "" {
 			stackParams["ImageId"] = environment.Cluster.ImageID
 		} else {


### PR DESCRIPTION
Make it possible to specify an extra user data script section in `mu.yml` that is appended to the general mu user data script.