### PR TITLE
use blue/green deploy as default

### DIFF
--- a/templates/assets/service-ecs.yml
+++ b/templates/assets/service-ecs.yml
@@ -217,8 +217,8 @@ Resources:
         Fn::ImportValue: !Sub ${EcsCluster}
       DesiredCount: !Ref ServiceDesiredCount
       DeploymentConfiguration:
-        MaximumPercent: 100
-        MinimumHealthyPercent: 0
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
       LaunchType:
         Fn::ImportValue: !Sub ${LaunchType}
       NetworkConfiguration:


### PR DESCRIPTION
This helps address https://github.com/stelligent/mu/issues/251 short-term... it should prevent downtime for services by default. For the occasional service that would benefit from a different strategy, having the configurable option would still be great. 