### PR TITLE
#283 Stripping all ., - and _ characters from revision ID

### DIFF
--- a/provider/aws/pipeline.go
+++ b/provider/aws/pipeline.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 
@@ -105,9 +104,9 @@ func (cplMgr *codePipelineManager) GetGitInfo(pipelineName string) (common.GitIn
 				}
 
 				if actionState.CurrentRevision != nil && actionState.CurrentRevision.RevisionId != nil {
-					fmt.Println(reflect.TypeOf(actionState.CurrentRevision.RevisionId))
-					// Remove leading period, if it exists
-					*actionState.CurrentRevision.RevisionId = strings.TrimPrefix(*actionState.CurrentRevision.RevisionId, ".")
+					// Remove invalid characters from RevisionID
+					replacer := strings.NewReplacer(".", "", "_", "", "-", "")
+					*actionState.CurrentRevision.RevisionId = replacer.Replace(*actionState.CurrentRevision.RevisionId)
 					gitInfo.Revision = aws.StringValue(actionState.CurrentRevision.RevisionId)
 				}
 				return gitInfo, nil

--- a/provider/aws/pipeline_test.go
+++ b/provider/aws/pipeline_test.go
@@ -177,7 +177,7 @@ func TestCodePipelineManager_GetGitInfo_S3(t *testing.T) {
 								Status: aws.String("Succeeded"),
 							},
 							CurrentRevision: &codepipeline.ActionRevision{
-								RevisionId: aws.String(".NN2QtU0xO2HlXFWnMb1C8bzsoP9eiG7q"),
+								RevisionId: aws.String(".N-N_2QtU0xO2HlXFWnMb1C8bzsoP9eiG7q"),
 							},
 						},
 					},


### PR DESCRIPTION
A deeper fix for issue #283. This strips all ., - and _ characters from the revision ID so it doesn't end up creating invalid Docker tags.