### PR TITLE
Update readme with info on go dep and make gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,12 @@ Want to contribute to Mu?  Awesome!  Check out the [contributing guidelines](CON
 ## Building from source
 
 * Ensure [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) is configured with an access key, secret access key, and region.
-* Install Go tools 1.7+ - (https://golang.org/doc/install)
+* Install Go tools 1.9+ - (https://golang.org/doc/install)
+* Install [Go Dep](https://golang.github.io/dep/docs/installation.html)
 * Clone this repo `git clone git@github.com:stelligent/mu.git $GOPATH/src/github.com/stelligent/mu`
 * Go to src `cd $GOPATH/src/github.com/stelligent/mu`
+* Run `dep ensure` to install dependencies
+* Run `make gen` to generate missing go files
 * Build with `make`
 * Run unit tests with `make test`
 * Run end-to-end tests with `make e2e`...takes about 30 minutes and will incur charges in your AWS account.


### PR DESCRIPTION
Change from go 1.7 to 1.9 for dep requirements.

There are many missing dependencies which can be installed
from the gopkg.toml using go dep. Install godep and run
dep ensure.

Building from source fails when running make. Missing
Asset (reference to templates/assets.go). This can be
fixed by running make gen.