### PR TITLE
Correctly warn if program version unparsable

### DIFF
--- a/provider/aws/cloudformation.go
+++ b/provider/aws/cloudformation.go
@@ -117,6 +117,9 @@ func (cfnMgr *cloudformationStackManager) UpsertStack(stackName string, template
 
 		if e1 != nil {
 			log.Warningf("Unable to parse major number for existing stack: %s", stack.Tags["version"])
+		}
+
+		if e2 != nil {
 			log.Warningf("Unable to parse major number for mu: %s", common.GetVersion())
 		}
 


### PR DESCRIPTION
Currently the conditional checking whether stack and program versions are parsable incorrectly warns of both problems when the stack version is unparsable, and never warns about the program version parsing if the stack is parsable.

This change fixes the logic