### PR TITLE
Switch database to use ssm-secure string instead of master password Parameter

### DIFF
--- a/common/param.go
+++ b/common/param.go
@@ -14,4 +14,5 @@ type ParamGetter interface {
 type ParamManager interface {
 	ParamGetter
 	ParamSetter
+	ParamExists(name string) (bool, error)
 }

--- a/common/param.go
+++ b/common/param.go
@@ -14,5 +14,5 @@ type ParamGetter interface {
 type ParamManager interface {
 	ParamGetter
 	ParamSetter
-	ParamExists(name string) (bool, error)
+	ParamExists(name string) (int64, error)
 }

--- a/common/param.go
+++ b/common/param.go
@@ -14,5 +14,5 @@ type ParamGetter interface {
 type ParamManager interface {
 	ParamGetter
 	ParamSetter
-	ParamExists(name string) (int64, error)
+	ParamVersion(name string) (int64, error)
 }

--- a/common/types.go
+++ b/common/types.go
@@ -153,17 +153,18 @@ type Database struct {
 
 // DatabaseConfig definition
 type DatabaseConfig struct {
-	Name                  string `yaml:"name,omitempty" validate:"validateLeadingAlphaNumericDash"`
-	InstanceClass         string `yaml:"instanceClass,omitempty" validate:"validateInstanceType"`
-	Engine                string `yaml:"engine,omitempty" validate:"validateAlphaNumericDash"`
-	EngineMode            string `yaml:"engineMode,omitempty" validate:"validateAlphaNumericDash"`
-	IamAuthentication     string `yaml:"iamAuthentication,omitempty"`
-	MasterUsername        string `yaml:"masterUsername,omitempty"`
-	AllocatedStorage      string `yaml:"allocatedStorage,omitempty"`
-	KmsKey                string `yaml:"kmsKey,omitempty"`
-	MinSize               string `yaml:"minSize,omitempty"`
-	MaxSize               string `yaml:"maxSize,omitempty"`
-	SecondsUntilAutoPause string `yaml:"secondsUntilAutoPause,omitempty"`
+	Name                   string `yaml:"name,omitempty" validate:"validateLeadingAlphaNumericDash"`
+	InstanceClass          string `yaml:"instanceClass,omitempty" validate:"validateInstanceType"`
+	Engine                 string `yaml:"engine,omitempty" validate:"validateAlphaNumericDash"`
+	EngineMode             string `yaml:"engineMode,omitempty" validate:"validateAlphaNumericDash"`
+	IamAuthentication      string `yaml:"iamAuthentication,omitempty"`
+	MasterUsername         string `yaml:"masterUsername,omitempty"`
+	AllocatedStorage       string `yaml:"allocatedStorage,omitempty"`
+	KmsKey                 string `yaml:"kmsKey,omitempty"`
+	MinSize                string `yaml:"minSize,omitempty"`
+	MaxSize                string `yaml:"maxSize,omitempty"`
+	SecondsUntilAutoPause  string `yaml:"secondsUntilAutoPause,omitempty"`
+	MasterPasswordSSMParam string `yaml:"masterPasswordSSMParam,omitempty"`
 }
 
 // GetDatabaseConfig definition
@@ -178,17 +179,18 @@ func (database *Database) GetDatabaseConfig(environmentName string) *DatabaseCon
 	}
 	envConfig := database.EnvironmentConfig[environmentName]
 	dbConfig := &DatabaseConfig{
-		Name:                  first(envConfig.Name, database.Name),
-		InstanceClass:         first(envConfig.InstanceClass, database.InstanceClass),
-		Engine:                first(envConfig.Engine, database.Engine),
-		EngineMode:            first(envConfig.EngineMode, database.EngineMode),
-		IamAuthentication:     first(envConfig.IamAuthentication, database.IamAuthentication),
-		MasterUsername:        first(envConfig.MasterUsername, database.MasterUsername),
-		AllocatedStorage:      first(envConfig.AllocatedStorage, database.AllocatedStorage),
-		KmsKey:                first(envConfig.KmsKey, database.KmsKey),
-		MinSize:               first(envConfig.MinSize, database.MinSize),
-		MaxSize:               first(envConfig.MaxSize, database.MaxSize),
-		SecondsUntilAutoPause: first(envConfig.SecondsUntilAutoPause, database.SecondsUntilAutoPause),
+		Name:                   first(envConfig.Name, database.Name),
+		InstanceClass:          first(envConfig.InstanceClass, database.InstanceClass),
+		Engine:                 first(envConfig.Engine, database.Engine),
+		EngineMode:             first(envConfig.EngineMode, database.EngineMode),
+		IamAuthentication:      first(envConfig.IamAuthentication, database.IamAuthentication),
+		MasterUsername:         first(envConfig.MasterUsername, database.MasterUsername),
+		AllocatedStorage:       first(envConfig.AllocatedStorage, database.AllocatedStorage),
+		KmsKey:                 first(envConfig.KmsKey, database.KmsKey),
+		MinSize:                first(envConfig.MinSize, database.MinSize),
+		MaxSize:                first(envConfig.MaxSize, database.MaxSize),
+		SecondsUntilAutoPause:  first(envConfig.SecondsUntilAutoPause, database.SecondsUntilAutoPause),
+		MasterPasswordSSMParam: first(envConfig.MasterPasswordSSMParam, database.MasterPasswordSSMParam),
 	}
 	return dbConfig
 }

--- a/provider/aws/cloudformation.go
+++ b/provider/aws/cloudformation.go
@@ -193,6 +193,7 @@ func updateStack(stackName string, stackParameters []*cloudformation.Parameter,
 		TemplateBody: templateBody,
 		Tags:         stackTags,
 	}
+
 	if policy, err := getPolicy(policy, cfnMgr.allowDataLoss); err != nil || policy != "" {
 		if err != nil {
 			return err

--- a/provider/aws/param.go
+++ b/provider/aws/param.go
@@ -68,8 +68,8 @@ func (paramMgr *paramManager) GetParam(name string) (string, error) {
 	return aws.StringValue(output.Parameters[0].Value), nil
 }
 
-// ParamExists checks if the parameter is set in SSM Parameter Store and return version
-func (paramMgr *paramManager) ParamExists(name string) (int64, error) {
+// ParamVersion checks if the parameter is set in SSM Parameter Store and return version
+func (paramMgr *paramManager) ParamVersion(name string) (int64, error) {
 	ssmAPI := paramMgr.ssmAPI
 
 	log.Debug("checking param exists '%s'", name)

--- a/provider/aws/param.go
+++ b/provider/aws/param.go
@@ -68,8 +68,8 @@ func (paramMgr *paramManager) GetParam(name string) (string, error) {
 	return aws.StringValue(output.Parameters[0].Value), nil
 }
 
-// ParamExists checks if the parameter is set in SSM Parameter Store
-func (paramMgr *paramManager) ParamExists(name string) (bool, error) {
+// ParamExists checks if the parameter is set in SSM Parameter Store and return version
+func (paramMgr *paramManager) ParamExists(name string) (int64, error) {
 	ssmAPI := paramMgr.ssmAPI
 
 	log.Debug("checking param exists '%s'", name)
@@ -86,12 +86,12 @@ func (paramMgr *paramManager) ParamExists(name string) (bool, error) {
 	output, err := ssmAPI.DescribeParameters(input)
 
 	if err != nil {
-		return false, err
+		return 0, err
 	}
 
 	if len(output.Parameters) != 1 {
-		return false, nil
+		return 0, nil
 	}
 
-	return true, nil
+	return *output.Parameters[0].Version, nil
 }

--- a/provider/aws/param.go
+++ b/provider/aws/param.go
@@ -67,3 +67,31 @@ func (paramMgr *paramManager) GetParam(name string) (string, error) {
 
 	return aws.StringValue(output.Parameters[0].Value), nil
 }
+
+// ParamExists checks if the parameter is set in SSM Parameter Store
+func (paramMgr *paramManager) ParamExists(name string) (bool, error) {
+	ssmAPI := paramMgr.ssmAPI
+
+	log.Debug("checking param exists '%s'", name)
+
+	input := &ssm.DescribeParametersInput{
+		Filters: []*ssm.ParametersFilter{
+			{
+				Key:    aws.String("Name"),
+				Values: []*string{aws.String(name)},
+			},
+		},
+	}
+
+	output, err := ssmAPI.DescribeParameters(input)
+
+	if err != nil {
+		return false, err
+	}
+
+	if len(output.Parameters) != 1 {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/provider/aws/param_test.go
+++ b/provider/aws/param_test.go
@@ -63,7 +63,7 @@ func TestParamManager_SetParam(t *testing.T) {
 	m.AssertNumberOfCalls(t, "PutParameter", 1)
 }
 
-func TestParamManager_ParamExists(t *testing.T) {
+func TestParamManager_ParamVersion(t *testing.T) {
 	assert := assert.New(t)
 
 	m := new(mockedSSM)
@@ -82,7 +82,7 @@ func TestParamManager_ParamExists(t *testing.T) {
 		ssmAPI: m,
 	}
 
-	val, err := paramMgr.ParamExists("foo")
+	val, err := paramMgr.ParamVersion("foo")
 	assert.Nil(err)
 	assert.Equal(int64(2), val)
 
@@ -90,7 +90,7 @@ func TestParamManager_ParamExists(t *testing.T) {
 	m.AssertNumberOfCalls(t, "DescribeParameters", 1)
 }
 
-func TestParamManager_ParamExistsFalse(t *testing.T) {
+func TestParamManager_ParamVersionFalse(t *testing.T) {
 	assert := assert.New(t)
 
 	m := new(mockedSSM)
@@ -104,7 +104,7 @@ func TestParamManager_ParamExistsFalse(t *testing.T) {
 		ssmAPI: m,
 	}
 
-	val, err := paramMgr.ParamExists("foo")
+	val, err := paramMgr.ParamVersion("foo")
 	assert.Nil(err)
 	assert.Equal(int64(0), val)
 

--- a/provider/aws/param_test.go
+++ b/provider/aws/param_test.go
@@ -70,7 +70,10 @@ func TestParamManager_ParamExists(t *testing.T) {
 	m.On("DescribeParameters").Return(
 		&ssm.DescribeParametersOutput{
 			Parameters: []*ssm.ParameterMetadata{
-				{Name: aws.String("foo")},
+				{
+					Name:    aws.String("foo"),
+					Version: aws.Int64(2),
+				},
 			},
 			NextToken: aws.String("bar"),
 		}, nil)
@@ -81,11 +84,12 @@ func TestParamManager_ParamExists(t *testing.T) {
 
 	val, err := paramMgr.ParamExists("foo")
 	assert.Nil(err)
-	assert.Equal(true, val)
+	assert.Equal(int64(2), val)
 
 	m.AssertExpectations(t)
 	m.AssertNumberOfCalls(t, "DescribeParameters", 1)
 }
+
 func TestParamManager_ParamExistsFalse(t *testing.T) {
 	assert := assert.New(t)
 
@@ -102,7 +106,7 @@ func TestParamManager_ParamExistsFalse(t *testing.T) {
 
 	val, err := paramMgr.ParamExists("foo")
 	assert.Nil(err)
-	assert.Equal(false, val)
+	assert.Equal(int64(0), val)
 
 	m.AssertExpectations(t)
 	m.AssertNumberOfCalls(t, "DescribeParameters", 1)

--- a/templates/assets/common-iam.yml
+++ b/templates/assets/common-iam.yml
@@ -306,6 +306,7 @@ Resources:
             - ec2:RevokeSecurityGroupIngress
             - ec2:AuthorizeSecurityGroupEgress
             - ec2:RevokeSecurityGroupEgress
+            - ssm:GetParameters
             Resource: '*'
             Effect: Allow
           - Action:

--- a/templates/assets/database.yml
+++ b/templates/assets/database.yml
@@ -30,10 +30,6 @@ Parameters:
     Type: String
     NoEcho: true
     Description: Username of database
-  DatabaseMasterPasswordSSMKey:
-    Type: AWS::SSM::Parameter::Name
-    NoEcho: true
-    Description: SSM parameter key to decrypt the Master Password
   DatabaseName:
     Type: String
     Description: Name of database

--- a/templates/assets/database.yml
+++ b/templates/assets/database.yml
@@ -33,6 +33,10 @@ Parameters:
   DatabaseName:
     Type: String
     Description: Name of database
+  DatabaseMasterPassword:
+    Type: String
+    NoEcho: true
+    Description: Password of database
   DatabaseStorage:
     Type: Number
     Description: Allocated storage for DB
@@ -141,7 +145,7 @@ Resources:
             - 'false'
         - AWS::NoValue
       MasterUsername: !Ref DatabaseMasterUsername
-      MasterUserPassword: '{{.Database.MasterPasswordSSMParam}}'
+      MasterUserPassword: !Ref DatabaseMasterPassword
       Tags:
       - Key: Name
         Value: !Ref DatabaseName
@@ -176,7 +180,7 @@ Resources:
       - Ref: DBSecurityGroup
       Engine: !Ref DatabaseEngine
       MasterUsername: !Ref DatabaseMasterUsername
-      MasterUserPassword: '{{.Database.MasterPasswordSSMParam}}'
+      MasterUserPassword: !Ref DatabaseMasterPassword
       Tags:
       - Key: Name
         Value: !Ref DatabaseName

--- a/templates/assets/database.yml
+++ b/templates/assets/database.yml
@@ -30,13 +30,13 @@ Parameters:
     Type: String
     NoEcho: true
     Description: Username of database
+  DatabaseMasterPasswordSSMKey:
+    Type: AWS::SSM::Parameter::Name
+    NoEcho: true
+    Description: SSM parameter key to decrypt the Master Password
   DatabaseName:
     Type: String
     Description: Name of database
-  DatabaseMasterPassword:
-    Type: String
-    NoEcho: true
-    Description: Password of database
   DatabaseStorage:
     Type: Number
     Description: Allocated storage for DB
@@ -145,7 +145,7 @@ Resources:
             - 'false'
         - AWS::NoValue
       MasterUsername: !Ref DatabaseMasterUsername
-      MasterUserPassword: !Ref DatabaseMasterPassword
+      MasterUserPassword: '{{.Database.MasterPasswordSSMParam}}'
       Tags:
       - Key: Name
         Value: !Ref DatabaseName
@@ -180,7 +180,7 @@ Resources:
       - Ref: DBSecurityGroup
       Engine: !Ref DatabaseEngine
       MasterUsername: !Ref DatabaseMasterUsername
-      MasterUserPassword: !Ref DatabaseMasterPassword
+      MasterUserPassword: '{{.Database.MasterPasswordSSMParam}}'
       Tags:
       - Key: Name
         Value: !Ref DatabaseName

--- a/templates/assets/service-ec2.yml
+++ b/templates/assets/service-ec2.yml
@@ -327,7 +327,6 @@ Resources:
           files:
             "/etc/environment":
               content: !Sub |
-                # created via mu
               {{with .Environment}}
               {{range $key, $val := .}}
                 {{$key}}={{$val}}

--- a/workflows/database_upsert.go
+++ b/workflows/database_upsert.go
@@ -103,19 +103,19 @@ func (workflow *databaseWorkflow) databaseDeployer(namespace string, service *co
 		common.NewMapElementIfNotEmpty(stackParams, "DatabaseMasterUsername", dbConfig.MasterUsername)
 
 		//DatabaseMasterPassword:
-		dbPass, err := paramManager.GetParam(fmt.Sprintf("%s-%s", dbStackName, "DatabaseMasterPassword"))
+		dbPassExists, err := paramManager.ParamExists(fmt.Sprintf("%s-%s", dbStackName, "DatabaseMasterPassword"))
 		if err != nil {
-			log.Warningf("Error with GetParam for DatabaseMasterPassword, assuming empty: %s", err)
-			dbPass = ""
+			// TODO: Should we prompt to allow overriding the password?
+			log.Warningf("Error with ParamExists for DatabaseMasterPassword, assuming empty: %s", err)
 		}
-		if dbPass == "" {
-			dbPass = randomPassword(32)
+		if !dbPassExists {
+			dbPass := randomPassword(32)
 			err = paramManager.SetParam(fmt.Sprintf("%s-%s", dbStackName, "DatabaseMasterPassword"), dbPass, workflow.databaseKeyArn)
 			if err != nil {
 				return err
 			}
 		}
-		stackParams["DatabaseMasterPassword"] = dbPass
+		// stackParams["DatabaseMasterPassword"] = dbPass
 
 		stackParams["DatabaseKeyArn"] = workflow.databaseKeyArn
 

--- a/workflows/database_upsert.go
+++ b/workflows/database_upsert.go
@@ -105,10 +105,9 @@ func (workflow *databaseWorkflow) databaseDeployer(namespace string, service *co
 		//DatabaseMasterPassword:
 		dbPassExists, err := paramManager.ParamExists(fmt.Sprintf("%s-%s", dbStackName, "DatabaseMasterPassword"))
 		if err != nil {
-			// TODO: Should we prompt to allow overriding the password?
 			log.Warningf("Error with ParamExists for DatabaseMasterPassword, assuming empty: %s", err)
 		}
-		if !dbPassExists {
+		if dbPassExists == 0 {
 			dbPass := randomPassword(32)
 			err = paramManager.SetParam(fmt.Sprintf("%s-%s", dbStackName, "DatabaseMasterPassword"), dbPass, workflow.databaseKeyArn)
 			if err != nil {

--- a/workflows/database_upsert.go
+++ b/workflows/database_upsert.go
@@ -118,8 +118,9 @@ func (workflow *databaseWorkflow) databaseDeployer(namespace string, service *co
 				dbPassVersion = 1
 			}
 			service.Database.MasterPasswordSSMParam = fmt.Sprintf("{{resolve:ssm-secure:%s:%d}}", dbPassSSMParam, dbPassVersion)
+		} else {
+			service.Database.MasterPasswordSSMParam = fmt.Sprintf("{{resolve:ssm-secure:%s}}", service.Database.MasterPasswordSSMParam)
 		}
-		stackParams["DatabaseMasterPasswordSSMKey"] = workflow.databaseKeyArn
 		stackParams["DatabaseKeyArn"] = workflow.databaseKeyArn
 
 		tags := createTagMap(&DatabaseTags{

--- a/workflows/database_upsert.go
+++ b/workflows/database_upsert.go
@@ -121,6 +121,7 @@ func (workflow *databaseWorkflow) databaseDeployer(namespace string, service *co
 		} else {
 			service.Database.MasterPasswordSSMParam = fmt.Sprintf("{{resolve:ssm-secure:%s}}", service.Database.MasterPasswordSSMParam)
 		}
+		stackParams["DatabaseMasterPassword"] = service.Database.MasterPasswordSSMParam
 		stackParams["DatabaseKeyArn"] = workflow.databaseKeyArn
 
 		tags := createTagMap(&DatabaseTags{

--- a/workflows/database_upsert_test.go
+++ b/workflows/database_upsert_test.go
@@ -37,6 +37,10 @@ func (m *mockedParamManager) SetParam(name string, value string, kmsKey string) 
 	args := m.Called(name)
 	return args.Error(0)
 }
+func (m *mockedParamManager) ParamExists(name string) (int64, error) {
+	args := m.Called(name)
+	return args.Get(0).(int64), args.Error(1)
+}
 
 func TestDatabaseUpserter_NoName(t *testing.T) {
 	assert := assert.New(t)
@@ -75,7 +79,7 @@ func TestDatabaseUpserter(t *testing.T) {
 	rdsManager.On("SetIamAuthentication", mock.Anything).Return(nil)
 
 	paramManager := new(mockedParamManager)
-	paramManager.On("GetParam", "mu-database-foo-dev-DatabaseMasterPassword").Return("dbpass", nil)
+	paramManager.On("ParamExists", "mu-database-foo-dev-DatabaseMasterPassword").Return(int64(1), nil)
 
 	config := new(common.Config)
 	config.Service.Name = "foo"
@@ -96,7 +100,7 @@ func TestDatabaseUpserter(t *testing.T) {
 	rdsManager.AssertNumberOfCalls(t, "SetIamAuthentication", 1)
 
 	paramManager.AssertExpectations(t)
-	paramManager.AssertNumberOfCalls(t, "GetParam", 1)
+	paramManager.AssertNumberOfCalls(t, "ParamExists", 1)
 
 }
 
@@ -111,7 +115,7 @@ func TestDatabaseUpserter_NoPass(t *testing.T) {
 	rdsManager.On("SetIamAuthentication", mock.Anything).Return(nil)
 
 	paramManager := new(mockedParamManager)
-	paramManager.On("GetParam", "mu-database-foo-dev-DatabaseMasterPassword").Return("", fmt.Errorf("no password"))
+	paramManager.On("ParamExists", "mu-database-foo-dev-DatabaseMasterPassword").Return(int64(0), fmt.Errorf("no password"))
 	paramManager.On("SetParam", "mu-database-foo-dev-DatabaseMasterPassword", mock.Anything).Return(nil)
 
 	config := new(common.Config)
@@ -133,7 +137,7 @@ func TestDatabaseUpserter_NoPass(t *testing.T) {
 	rdsManager.AssertNumberOfCalls(t, "SetIamAuthentication", 1)
 
 	paramManager.AssertExpectations(t)
-	paramManager.AssertNumberOfCalls(t, "GetParam", 1)
+	paramManager.AssertNumberOfCalls(t, "ParamExists", 1)
 	paramManager.AssertNumberOfCalls(t, "SetParam", 1)
 
 }
@@ -149,7 +153,7 @@ func TestDatabaseUpserter_ExistingPass(t *testing.T) {
 	rdsManager.On("SetIamAuthentication", mock.Anything).Return(nil)
 
 	paramManager := new(mockedParamManager)
-	paramManager.On("GetParam", "mu-database-foo-dev-DatabaseMasterPassword").Return("foobarbaz", nil)
+	paramManager.On("ParamExists", "mu-database-foo-dev-DatabaseMasterPassword").Return(int64(1), nil)
 
 	config := new(common.Config)
 	config.Service.Name = "foo"
@@ -170,7 +174,7 @@ func TestDatabaseUpserter_ExistingPass(t *testing.T) {
 	rdsManager.AssertNumberOfCalls(t, "SetIamAuthentication", 1)
 
 	paramManager.AssertExpectations(t)
-	paramManager.AssertNumberOfCalls(t, "GetParam", 1)
+	paramManager.AssertNumberOfCalls(t, "ParamExists", 1)
 	paramManager.AssertNumberOfCalls(t, "SetParam", 0)
 
 }


### PR DESCRIPTION
The database master password is now derived from the dynamic reference of an ssm-secure string instead of being pulled, decrypted, and passed as a parameter. This means the only time the decrypted password is on the machine is:

 - When [services are upserted](https://github.com/stelligent/mu/blob/issue-343/workflows/service_deploy.go#L275) (used for injection)
 - If the user explicitly [sets or gets the password](https://github.com/stelligent/mu/blob/issue-343/workflows/database_params.go#L21)
 - And when the password is unset - a new one is generated, encrypted, and put in parameter store

In the future it would be nice to parse the services file environment and determine if we need to pull the database password from the param store. This way we only pull the parameter and inject it when absolutely necessary.