### PR TITLE
Allows ecs-fargate services to be created with a public IP

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -150,6 +150,7 @@ type Service struct {
 	CPU                  int                    `yaml:"cpu,omitempty"`
 	Memory               int                    `yaml:"memory,omitempty"`
 	NetworkMode          NetworkMode            `yaml:"networkMode,omitempty"`
+	AssignPublicIP       bool                   `yaml:"assignPublicIp,omitempty"`
 	Links                []string               `yaml:"links,omitempty"`
 	Environment          map[string]interface{} `yaml:"environment,omitempty"`
 	PathPatterns         []string               `yaml:"pathPatterns,omitempty"`

--- a/templates/assets/cloudformation/service-ecs.yml
+++ b/templates/assets/cloudformation/service-ecs.yml
@@ -157,6 +157,13 @@ Parameters:
   ServiceDiscoveryName:
     Type: String
     Description: Name of the value to import for the service discovery namespace name
+  AssignPublicIp:
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: Whether to assign a public IP to the service, this is only applicable to awsvpc networked tasks
 Conditions:
   HasPathPattern:
     "Fn::Not":
@@ -225,6 +232,11 @@ Conditions:
       - "Fn::Equals":
         - !Ref TaskCpu
         - ''
+
+  IsAssignPublicIpEnabled:
+    "Fn::Equals":
+      - !Ref AssignPublicIp
+      - 'true'
 Resources:
   EcsServiceName:
     Type: AWS::ServiceDiscovery::Service
@@ -268,6 +280,11 @@ Resources:
                 Fn::Split:
                 - ","
                 - Fn::ImportValue: !Sub ${ServiceSubnetIds}
+              AssignPublicIp:
+                Fn::If:
+                  - IsAssignPublicIpEnabled
+                  - 'ENABLED'
+                  - 'DISABLED'
           - !Ref AWS::NoValue
       LoadBalancers:
         - Fn::If:

--- a/templates/assets/cloudformation/service-ecs.yml
+++ b/templates/assets/cloudformation/service-ecs.yml
@@ -283,8 +283,8 @@ Resources:
               AssignPublicIp:
                 Fn::If:
                   - IsAssignPublicIpEnabled
-                  - 'ENABLED'
-                  - 'DISABLED'
+                  - ENABLED
+                  - DISABLED
           - !Ref AWS::NoValue
       LoadBalancers:
         - Fn::If:

--- a/workflows/service_deploy.go
+++ b/workflows/service_deploy.go
@@ -191,6 +191,8 @@ func (workflow *serviceWorkflow) serviceApplyEcsParams(service *common.Service, 
 			params["Links"] = strings.Join(service.Links, ",")
 		}
 
+		params["AssignPublicIp"] = strconv.FormatBool(service.AssignPublicIP)
+
 		// force 'awsvpc' network mode for ecs-fargate
 		if strings.EqualFold(string(workflow.envStack.Tags["provider"]), string(common.EnvProviderEcsFargate)) {
 			params["TaskNetworkMode"] = common.NetworkModeAwsVpc


### PR DESCRIPTION
This closes #369 by adding a new boolean `assignPublicIp` property to services. This currently only applies to the `ecs-fargate` provider when in the awsvpc network mode (the default, and only value) per https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-awsvpcconfiguration.html#cfn-ecs-service-awsvpcconfiguration-assignpublicip