### PR TITLE
Issue-371: Template decorator error catcher; env-ecs.yml fix

### DIFF
--- a/provider/aws/cloudformation.go
+++ b/provider/aws/cloudformation.go
@@ -323,6 +323,9 @@ func (cfnMgr *cloudformationStackManager) UpsertStack(stackName string, template
 	// load the template
 	templateBody, err := templates.GetAsset(templateName, templates.ExecuteTemplate(templateData),
 		templates.DecorateTemplate(cfnMgr.extensionsManager, stackName))
+	if err != nil {
+		return err
+	}
 	templateBodyBytes := bytes.NewBufferString(templateBody)
 
 	// stack parameters

--- a/provider/aws/cloudformation_test.go
+++ b/provider/aws/cloudformation_test.go
@@ -152,7 +152,7 @@ func TestStack_UpsertStack_Create(t *testing.T) {
 		cfnAPI:            cfn,
 		extensionsManager: extMgr,
 	}
-	err := stackManager.UpsertStack("foo", "bucket.yml", nil, nil, nil, "", "")
+	err := stackManager.UpsertStack("foo", "cloudformation/bucket.yml", nil, nil, nil, "", "")
 
 	assert.Nil(err)
 	cfn.AssertExpectations(t)
@@ -186,7 +186,7 @@ func TestStack_UpsertStack_Update(t *testing.T) {
 		cfnAPI:            cfn,
 		extensionsManager: extMgr,
 	}
-	err := stackManager.UpsertStack("foo", "bucket.yml", nil, nil, nil, "", "")
+	err := stackManager.UpsertStack("foo", "cloudformation/bucket.yml", nil, nil, nil, "", "")
 
 	assert.Nil(err)
 	cfn.AssertExpectations(t)
@@ -411,7 +411,7 @@ func TestStack_UpsertStack_CreatePolicy(t *testing.T) {
 	cfn := mockBasicCfnAPI(true)
 	extMgr := mockNilExtensionManager()
 
-	templateName := "bucket.yml"
+	templateName := "cloudformation/bucket.yml"
 	var templateData interface{}
 	stackName := "foo"
 
@@ -442,7 +442,7 @@ func TestStack_UpsertStack_CreatePolicyAllowDataLoss(t *testing.T) {
 	cfn := mockBasicCfnAPI(true)
 	extMgr := mockNilExtensionManager()
 
-	templateName := "bucket.yml"
+	templateName := "cloudformation/bucket.yml"
 	var templateData interface{}
 	stackName := "foo"
 
@@ -474,7 +474,7 @@ func TestStack_UpsertStack_UpdatePolicy(t *testing.T) {
 	cfn := mockBasicCfnAPI(false)
 	extMgr := mockNilExtensionManager()
 
-	templateName := "bucket.yml"
+	templateName := "cloudformation/bucket.yml"
 	var templateData interface{}
 	stackName := "foo"
 
@@ -506,7 +506,7 @@ func TestStack_UpsertStack_UpdatePolicyAllowDataLoss(t *testing.T) {
 	cfn := mockBasicCfnAPI(false)
 	extMgr := mockNilExtensionManager()
 
-	templateName := "bucket.yml"
+	templateName := "cloudformation/bucket.yml"
 	var templateData interface{}
 	stackName := "foo"
 

--- a/templates/assets/cloudformation/env-ecs.yml
+++ b/templates/assets/cloudformation/env-ecs.yml
@@ -240,7 +240,8 @@ Resources:
         - Enabled
       Targets:
       - Key: tag:aws:autoscaling:groupName	
-        Values: [!Ref EcsAutoScalingGroup]
+        Values: 
+          - !Ref EcsAutoScalingGroup
   ContainerInstances:
     Condition: HasLaunchTypeEC2
     Type: AWS::AutoScaling::LaunchConfiguration


### PR DESCRIPTION
Issue https://github.com/stelligent/mu/issues/371
Simple fix, took some time to figure out how this works.
