### PR TITLE
Map deployment strategy to eks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,21 @@ e2e: gen stage keypair
 	@echo "=== e2e testing ==="
 	@MU_VERSION=$(VERSION) MU_BASEURL=https://mu-staging-$$(aws sts get-caller-identity --output text --query 'Account').s3.amazonaws.com go test -v ./e2e -timeout 60m
 
+e2e_basic: gen stage keypair
+	@echo "=== e2e-basic testing ==="
+	@INCLUDE_TESTS=e2e-basic MU_VERSION=$(VERSION) MU_BASEURL=https://mu-staging-$$(aws sts get-caller-identity --output text --query 'Account').s3.amazonaws.com go test -v ./e2e -timeout 60m
+
+e2e_ec2: gen stage keypair
+	@echo "=== e2e-ec2 testing ==="
+	@INCLUDE_TESTS=e2e-ec2 MU_VERSION=$(VERSION) MU_BASEURL=https://mu-staging-$$(aws sts get-caller-identity --output text --query 'Account').s3.amazonaws.com go test -v ./e2e -timeout 60m
+
+e2e_eks: gen stage keypair
+	@echo "=== e2e-eks testing ==="
+	@INCLUDE_TESTS=e2e-eks MU_VERSION=$(VERSION) MU_BASEURL=https://mu-staging-$$(aws sts get-caller-identity --output text --query 'Account').s3.amazonaws.com go test -v ./e2e -timeout 60m
+
+e2e_fargate: gen stage keypair
+	@echo "=== e2e-fargate testing ==="
+	@INCLUDE_TESTS=e2e-fargate MU_VERSION=$(VERSION) MU_BASEURL=https://mu-staging-$$(aws sts get-caller-identity --output text --query 'Account').s3.amazonaws.com go test -v ./e2e -timeout 60m
 
 check_github_token:
 ifndef GITHUB_TOKEN

--- a/common/types.go
+++ b/common/types.go
@@ -395,8 +395,8 @@ type DeploymentStrategy string
 // List of supported deployment strategies
 const (
 	BlueGreenDeploymentStrategy DeploymentStrategy = "blue_green"
-	RollingDeploymentStrategy                      = "rolling"
-	ReplaceDeploymentStrategy                      = "replace"
+	RollingDeploymentStrategy   DeploymentStrategy = "rolling"
+	ReplaceDeploymentStrategy   DeploymentStrategy = "replace"
 )
 
 // EnvProvider describes supported environment strategies

--- a/e2e/e2e-eks/mu.yml
+++ b/e2e/e2e-eks/mu.yml
@@ -1,5 +1,3 @@
----
-
 environments:
   - name: e2e-eks-dev
     provider: eks
@@ -26,6 +24,6 @@ service:
       disabled: true
 
 rbac:
-- role: admin
-  user:
-  - casey.lee
+  - role: admin
+    users:
+      - casey.lee

--- a/e2e/pipeline_test.go
+++ b/e2e/pipeline_test.go
@@ -35,6 +35,9 @@ import (
 
 var contexts []*common.Context
 
+// TestMain accepts a type *testing.M to override the primary main function to allow
+// custom setup and tear down code. Eventually, m.Run() is called to invoke all
+// tests of the general syntax (func Test*).
 func TestMain(m *testing.M) {
 	sessOptions := session.Options{SharedConfigState: session.SharedConfigEnable}
 	sess, err := session.NewSessionWithOptions(sessOptions)
@@ -60,11 +63,18 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		retCode = 1
 	} else {
+		// this invokes all func Test* functions in this file
 		retCode = m.Run()
 	}
 
-	teardownContexts(sess)
-	os.RemoveAll(dir)
+	if retCode == 0 {
+		fmt.Println("E2E test succeeded, cleaning up resources")
+		teardownContexts(sess)
+		os.RemoveAll(dir)
+	} else {
+		fmt.Println("E2E tests encountered an error, skipping cleaning up to allow debugging")
+	}
+
 	os.Exit(retCode)
 }
 

--- a/templates/assets/cloudformation/service-iam.yml
+++ b/templates/assets/cloudformation/service-iam.yml
@@ -378,7 +378,7 @@ Resources:
         - Effect: Allow
           Principal:
             Service:
-            - ecs-tasks.amazonaws.com
+            - eks.amazonaws.com
           Action:
           - sts:AssumeRole
       Path: "/"

--- a/templates/assets/kubernetes/deployment.yml
+++ b/templates/assets/kubernetes/deployment.yml
@@ -32,8 +32,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: {{ .MinimumHealthyPercent }}%
-      maxSurge: {{ .MaximumPercent }}%
+      maxUnavailable: {{ .MaxUnavailable }}%
+      maxSurge: {{ .MaxSurge }}%
   {{ end }}
   template:
     metadata:

--- a/templates/assets/kubernetes/deployment.yml
+++ b/templates/assets/kubernetes/deployment.yml
@@ -25,6 +25,16 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ .ServiceName }}-deployment
       app.kubernetes.io/part-of: {{ .ServiceName }}
+  {{ if eq .DeploymentStrategy "replace" }} # see common/types.go DeploymentStrategy types for valid string values
+  strategy:
+    type: Recreate
+  {{ else }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .MinimumHealthyPercent }}%
+      maxSurge: {{ .MaximumPercent }}%
+  {{ end }}
   template:
     metadata:
       labels:
@@ -145,6 +155,6 @@ spec:
       - backend:
           serviceName: {{ $.ServiceName}}
           servicePort: {{ $.ServicePort }}
-        path: "{{.}}" 
+        path: "{{.}}"
   {{end}}
 {{end}}

--- a/workflows/service_deploy.go
+++ b/workflows/service_deploy.go
@@ -454,7 +454,9 @@ func (workflow *serviceWorkflow) serviceEksDeployer(namespace string, service *c
 			"Revision":              workflow.codeRevision,
 			"MuVersion":             common.GetVersion(),
 			"EnvVariables":          service.Environment,
+			"DeploymentStrategy":    service.DeploymentStrategy,
 		}
+		templateData["MinimumHealthyPercent"], templateData["MaximumPercent"] = getMinMaxPercentForStrategy(service.DeploymentStrategy)
 
 		if stackParams["DatabaseName"] != "" {
 			templateData["DatabaseSecretName"] = fmt.Sprintf("%s-database", workflow.serviceName)

--- a/workflows/service_deploy.go
+++ b/workflows/service_deploy.go
@@ -416,6 +416,8 @@ func (workflow *serviceWorkflow) serviceEksDBSecret(namespace string, service *c
 	}
 }
 
+// serviceEksDeployer accepts a service and its information and upserts a kubernetes Pod file to
+// a k8s cluster
 func (workflow *serviceWorkflow) serviceEksDeployer(namespace string, service *common.Service, stackParams map[string]string, environmentName string) Executor {
 	return func() error {
 		log.Noticef("Deploying service '%s' to '%s' from '%s'", workflow.serviceName, environmentName, workflow.serviceImage)

--- a/workflows/service_deploy.go
+++ b/workflows/service_deploy.go
@@ -454,8 +454,9 @@ func (workflow *serviceWorkflow) serviceEksDeployer(namespace string, service *c
 			"Revision":              workflow.codeRevision,
 			"MuVersion":             common.GetVersion(),
 			"EnvVariables":          service.Environment,
-			"DeploymentStrategy":    service.DeploymentStrategy,
+			"DeploymentStrategy":    string(service.DeploymentStrategy),
 		}
+		// see common/types.go DeploymentStrategy types for valid string values
 		templateData["MinimumHealthyPercent"], templateData["MaximumPercent"] = getMinMaxPercentForStrategy(service.DeploymentStrategy)
 
 		if stackParams["DatabaseName"] != "" {

--- a/workflows/service_deploy.go
+++ b/workflows/service_deploy.go
@@ -420,8 +420,6 @@ func (workflow *serviceWorkflow) serviceEksDeployer(namespace string, service *c
 	return func() error {
 		log.Noticef("Deploying service '%s' to '%s' from '%s'", workflow.serviceName, environmentName, workflow.serviceImage)
 
-		resolveServiceEnvironment(service, environmentName)
-
 		servicePort := 8080
 		if service.Port != 0 {
 			servicePort = service.Port

--- a/workflows/service_deploy_test.go
+++ b/workflows/service_deploy_test.go
@@ -196,6 +196,7 @@ func TestServiceEcsDeployer(t *testing.T) {
 
 }
 
+// mockKubernetesResourceManager mocks common/kubernetes.go:KubernetesResourceManager
 type mockKubernetesResourceManager struct {
 	mock.Mock
 }
@@ -219,6 +220,9 @@ func (m *mockKubernetesResourceManager) DeleteResource(apiVersion string, kind s
 	return args.Error(0)
 }
 
+// TestServiceEksDeployer tests that serviceWorkflow.serviceEksDeployer
+// calls the kubernetesResourceManager.UpsertResources method once. It
+// does not test the output of that call.
 func TestServiceEksDeployer(t *testing.T) {
 	assert := assert.New(t)
 
@@ -238,7 +242,6 @@ func TestServiceEksDeployer(t *testing.T) {
 	workflow.envStack = &common.Stack{Name: "mu-environment-dev", Status: common.StackStatusCreateComplete, Outputs: outputs}
 	workflow.lbStack = &common.Stack{Name: "mu-loadbalancer-dev", Status: common.StackStatusCreateComplete, Outputs: outputs}
 	workflow.kubernetesResourceManager = kubernetesResourceManager
-	// err := workflow.serviceEcsDeployer("mu", &config.Service, params, "dev", stackManager, stackManager)()
 	err := workflow.serviceEksDeployer("mu", &config.Service, params, "dev")()
 	assert.Nil(err)
 

--- a/workflows/service_deploy_test.go
+++ b/workflows/service_deploy_test.go
@@ -195,6 +195,10 @@ func TestServiceEcsDeployer(t *testing.T) {
 
 }
 
+func TestServiceEksDeployer(t *testing.T) {
+	panic("TODO: implement this test")
+}
+
 func stringRef(v string) *string {
 	return &v
 }


### PR DESCRIPTION
Closes #359.

Functional testing of each strategy complete. There is an issue where you can't change your deployment strategy from blue_green or rolling to replace after the EKS cluster has been created (and likely vice versa, didn't check), but I don't expect it to be much of a problem. Changing from blue_green to rolling and back works fine.