### PR TITLE
examples/service-env-vars: use 'acceptance' and 'production' for env names

### DIFF
--- a/examples/service-env-vars/mu.yml
+++ b/examples/service-env-vars/mu.yml
@@ -5,5 +5,5 @@ service:
   environment:
     DB_TYPE: mysql                  # Define an environment variable for all environments by have a string for value
     DB_URL:                         # Define an different value per environment by have a map for value
-        dev:  10.0.0.1:3306
-        prod: 10.0.100.5:3306
+        acceptance:  10.0.0.1:3306
+        production: 10.0.100.5:3306


### PR DESCRIPTION
This example is a bit less confusing if it uses the environment names that most people are using.

It'd also be helpful if the [Services#Configuration](https://github.com/stelligent/mu/wiki/Services#configuration) section of the wiki could also be updated as "acpt" and "prod" do not seem to work, instead they should be "acceptance" and "production".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stelligent/mu/386)
<!-- Reviewable:end -->
