### PR TITLE
expose LoadBalancerAttributes on Environment

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -109,10 +109,11 @@ type Environment struct {
 
 // Loadbalancer defines the scructure of the yml file for a loadbalancer
 type Loadbalancer struct {
-	HostedZone  string `yaml:"hostedzone,omitempty" validate:"validateURL"`
-	Name        string `yaml:"name,omitempty"  validate:"validateLeadingAlphaNumericDash=32"`
-	Certificate string `yaml:"certificate,omitempty"`
-	Internal    bool   `yaml:"internal,omitempty"`
+	HostedZone  string            `yaml:"hostedzone,omitempty" validate:"validateURL"`
+	Name        string            `yaml:"name,omitempty"  validate:"validateLeadingAlphaNumericDash=32"`
+	Certificate string            `yaml:"certificate,omitempty"`
+	Internal    bool              `yaml:"internal,omitempty"`
+	Attributes  map[string]string `yaml:"attributes,omitempty"`
 }
 
 // Cluster defines the scructure of the yml file for a cluster of EC2 instance AWS::AutoScaling::LaunchConfiguration

--- a/templates/assets/cloudformation/elb.yml
+++ b/templates/assets/cloudformation/elb.yml
@@ -136,6 +136,15 @@ Resources:
         Value: !Ref AWS::StackName
       SecurityGroups:
       - !Ref ElbSG
+      {{if .Loadbalancer.Attributes}}
+      LoadBalancerAttributes:
+      {{with .Loadbalancer.Attributes}}
+        {{range $key, $val := .}}
+      - Key: {{$key}}
+        Value: !Sub {{$val}}
+        {{end}}
+      {{end}}
+      {{end}}
   ElbHttpListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:


### PR DESCRIPTION
As an example, ALB access logs can now be enabled by setting:

```
  environments:
    - name: production
      loadbalancer:
        attributes:
          access_logs.s3.enabled: true
          access_logs.s3.prefix: ${Namespace}/access-logs
          access_logs.s3.bucket: myorg-logs-${EnvironmentName}
```

Resolves: #387

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stelligent/mu/388)
<!-- Reviewable:end -->
