### PR TITLE
Issue 406

### DIFF
--- a/templates/assets/cloudformation/artifact-pipeline.yml
+++ b/templates/assets/cloudformation/artifact-pipeline.yml
@@ -11,6 +11,16 @@ Parameters:
   SourceBranch:
     Type: String
     Description: Branch to trigger pipeline
+  {{if eq .SourceProvider "S3" -}}
+  SourceBucket:
+    Type: String
+    Description: Source Bucket
+    Default: ""
+  SourceObjectKey:
+    Type: String
+    Description: Source Object Key
+    Default: ""
+  {{- end}}
   {{if eq .SourceProvider "GitHub" -}}
   GitHubToken:
     NoEcho: true
@@ -90,6 +100,10 @@ Resources:
         CodeDeployBucket: {{ .CodeDeployBucket }}
         SourceProvider: {{ .SourceProvider }}
         SourceRepo: !Ref SourceRepo
+        {{if eq .SourceProvider "S3" -}}
+        SourceBucket: !Ref SourceBucket
+        SourceObjectKey: !Ref SourceObjectKey
+        {{- end}}
         {{if eq .EnableAcptStage "true" -}}
         AcptEnv: {{ .AcptEnv }}
         {{- end}}
@@ -103,7 +117,7 @@ Resources:
         AcptCloudFormationRoleArn: {{ .AcptCloudFormationRoleArn }}
         {{- end}}
         {{if eq .EnableProdStage "true" -}}
-	      ProdCloudFormationRoleArn: {{ .ProdCloudFormationRoleArn }}
+        ProdCloudFormationRoleArn: {{ .ProdCloudFormationRoleArn }}
         {{- end}}
       Tags:
         - Key: mu:name
@@ -130,6 +144,10 @@ Resources:
         SourceProvider: {{ .SourceProvider }}
         SourceRepo: !Ref SourceRepo
         SourceBranch: !Ref SourceBranch
+        {{if eq .SourceProvider "S3" -}}
+        SourceBucket: !Ref SourceBucket
+        SourceObjectKey: !Ref SourceObjectKey
+        {{- end}}
         {{if eq .SourceProvider "GitHub" -}}
         GitHubToken: !Ref GitHubToken
         {{- end}}

--- a/templates/assets/cloudformation/pipeline.yml
+++ b/templates/assets/cloudformation/pipeline.yml
@@ -428,8 +428,12 @@ Resources:
                     - HasGitHubToken
                     - !Ref GitHubToken
                     - !Ref AWS::NoValue
-              - RepositoryName: !Ref SourceRepo
-                BranchName: !Ref SourceBranch
+              -
+                Fn::If:
+                - IsCodeCommit
+                - RepositoryName: !Ref SourceRepo
+                  BranchName: !Ref SourceBranch
+                - !Ref AWS::NoValue
           RunOrder: 10
       - Fn::If:
         - IsBuildEnabled

--- a/templates/assets/cloudformation/pipeline.yml
+++ b/templates/assets/cloudformation/pipeline.yml
@@ -408,14 +408,10 @@ Resources:
                 Owner: ThirdParty
                 Version: '1'
                 Provider: GitHub
-              -
-                Fn::If:
-                - IsCodeCommit
-                - Category: Source
-                  Owner: AWS
-                  Version: '1'
-                  Provider: CodeCommit
-                - !Ref AWS::NoValue
+              - Category: Source
+                Owner: AWS
+                Version: '1'
+                Provider: CodeCommit
           Configuration:
             Fn::If:
             - IsS3
@@ -432,12 +428,8 @@ Resources:
                     - HasGitHubToken
                     - !Ref GitHubToken
                     - !Ref AWS::NoValue
-              -
-                Fn::If:
-                - IsCodeCommit
-                - RepositoryName: !Ref SourceRepo
-                  BranchName: !Ref SourceBranch
-                - !Ref AWS::NoValue
+              - RepositoryName: !Ref SourceRepo
+                BranchName: !Ref SourceBranch
           RunOrder: 10
       - Fn::If:
         - IsBuildEnabled

--- a/templates/assets/cloudformation/pipeline.yml
+++ b/templates/assets/cloudformation/pipeline.yml
@@ -408,10 +408,14 @@ Resources:
                 Owner: ThirdParty
                 Version: '1'
                 Provider: GitHub
-              - Category: Source
-                Owner: AWS
-                Version: '1'
-                Provider: CodeCommit
+              -
+                Fn::If:
+                - IsCodeCommit
+                - Category: Source
+                  Owner: AWS
+                  Version: '1'
+                  Provider: CodeCommit
+                - !Ref AWS::NoValue
           Configuration:
             Fn::If:
             - IsS3

--- a/workflows/pipeline_upsert.go
+++ b/workflows/pipeline_upsert.go
@@ -254,7 +254,7 @@ func (workflow *pipelineWorkflow) pipelineCatalogUpserter(namespace string, pipe
 		productParams["ServiceName"] = workflow.serviceName
 		productParams["SourceBranch"] = workflow.codeBranch
 		productParams["SourceRepo"] = pipeline.Source.Repo
-		productParams["GitHubToken"] = params["GitHubToken"]
+		//productParams["GitHubToken"] = params["GitHubToken"]
 
 		return catalogProvisioner.UpsertProvisionedProduct(stack.Outputs["ProductId"], pipeline.Catalog.Version, fmt.Sprintf("%s-%s", namespace, workflow.serviceName), productParams)
 	}

--- a/workflows/pipeline_upsert.go
+++ b/workflows/pipeline_upsert.go
@@ -254,7 +254,16 @@ func (workflow *pipelineWorkflow) pipelineCatalogUpserter(namespace string, pipe
 		productParams["ServiceName"] = workflow.serviceName
 		productParams["SourceBranch"] = workflow.codeBranch
 		productParams["SourceRepo"] = pipeline.Source.Repo
-		//productParams["GitHubToken"] = params["GitHubToken"]
+
+		if pipeline.Source.Provider == "GitHub" {
+			productParams["GitHubToken"] = params["GitHubToken"]
+		}
+
+		if pipeline.Source.Provider == "S3" {
+			repoParts := strings.Split(pipeline.Source.Repo, "/")
+			productParams["SourceBucket"] = repoParts[0]
+			productParams["SourceObjectKey"] = strings.Join(repoParts[1:], "/")
+		}
 
 		return catalogProvisioner.UpsertProvisionedProduct(stack.Outputs["ProductId"], pipeline.Catalog.Version, fmt.Sprintf("%s-%s", namespace, workflow.serviceName), productParams)
 	}

--- a/workflows/pipeline_upsert.go
+++ b/workflows/pipeline_upsert.go
@@ -252,8 +252,13 @@ func (workflow *pipelineWorkflow) pipelineCatalogUpserter(namespace string, pipe
 
 		productParams := make(map[string]string)
 		productParams["ServiceName"] = workflow.serviceName
-		productParams["SourceBranch"] = workflow.codeBranch
 		productParams["SourceRepo"] = pipeline.Source.Repo
+
+		if workflow.codeBranch != "" {
+			productParams["SourceBranch"] = workflow.codeBranch
+		} else {
+			productParams["SourceBranch"] = pipeline.Source.Branch
+		}
 
 		if pipeline.Source.Provider == "GitHub" {
 			productParams["GitHubToken"] = params["GitHubToken"]


### PR DESCRIPTION
This changeset fixes an issue with using S3 as the SourceProvider of a pipeline generated from ServiceCatalog. 

Previously, when selecting S3 as a SourceProvider, it would not provide the SourceBucket or SourceObjectKey parameters that are required to pass on to the pipeline.yml template. 

The conditional statement in PipelineParams of pipeline_upsert.go that splits the S3 repository into its SourceBucket and SourceObjectKey parts is added to the pipelineCatalogUpserter function.

This changeset also fixes an issue in the pipelineCatalogUpserter workflow where it would not properly set the SourceBranch value.