### PR TITLE
Elb: if there's a cert, redirect http to https

### DIFF
--- a/templates/assets/cloudformation/service-ec2.yml
+++ b/templates/assets/cloudformation/service-ec2.yml
@@ -505,8 +505,15 @@ Resources:
     Condition: HasElbHttpPathListener
     Properties:
       Actions:
-      - Type: forward
-        TargetGroupArn: !Ref ElbTargetGroup
+        - Fn::If:
+            - HasElbHttpsPathListener
+            - Type: redirect
+              RedirectConfig:
+                Port: "443"
+                Protocol: HTTPS
+                StatusCode: HTTP_301
+            - Type: forward
+              TargetGroupArn: !Ref ElbTargetGroup
       Conditions:
       - Field: path-pattern
         Values: !Ref PathPattern
@@ -531,8 +538,15 @@ Resources:
     Condition: HasElbHttpHostListener
     Properties:
       Actions:
-      - Type: forward
-        TargetGroupArn: !Ref ElbTargetGroup
+        - Fn::If:
+            - HasElbHttpsHostListener
+            - Type: redirect
+              RedirectConfig:
+                Port: "443"
+                Protocol: HTTPS
+                StatusCode: HTTP_301
+            - Type: forward
+              TargetGroupArn: !Ref ElbTargetGroup
       Conditions:
       - Field: host-header
         Values: !Ref HostPattern

--- a/templates/assets/cloudformation/service-ecs.yml
+++ b/templates/assets/cloudformation/service-ecs.yml
@@ -401,8 +401,15 @@ Resources:
     Condition: HasElbHttpPathListener
     Properties:
       Actions:
-      - Type: forward
-        TargetGroupArn: !Ref ElbTargetGroup
+        - Fn::If:
+            - HasElbHttpsPathListener
+            - Type: redirect
+              RedirectConfig:
+                Port: "443"
+                Protocol: HTTPS
+                StatusCode: HTTP_301
+            - Type: forward
+              TargetGroupArn: !Ref ElbTargetGroup
       Conditions:
       - Field: path-pattern
         Values: !Ref PathPattern
@@ -427,8 +434,15 @@ Resources:
     Condition: HasElbHttpHostListener
     Properties:
       Actions:
-      - Type: forward
-        TargetGroupArn: !Ref ElbTargetGroup
+        - Fn::If:
+            - HasElbHttpsHostListener
+            - Type: redirect
+              RedirectConfig:
+                Port: "443"
+                Protocol: HTTPS
+                StatusCode: HTTP_301
+            - Type: forward
+              TargetGroupArn: !Ref ElbTargetGroup
       Conditions:
       - Field: host-header
         Values: !Ref HostPattern


### PR DESCRIPTION
Currently if a user visits a mu elb with http, they are not redirected
to https. In the mu spirit of taking opinionated stances, the right
default behavior should be to redirect to https where available.

The cloudformation support for redirect didn't exist a month ago;
I suspect it was quietly released around "re: invent".