### PR TITLE
Add PollForSourceChanges attribute

### DIFF
--- a/templates/assets/cloudformation/pipeline.yml
+++ b/templates/assets/cloudformation/pipeline.yml
@@ -428,6 +428,11 @@ Resources:
                     - HasGitHubToken
                     - !Ref GitHubToken
                     - !Ref AWS::NoValue
+                PollForSourceChanges:
+                  Fn::If:
+                    - HasGitHubToken
+                    - "false"
+                    - "true"
               - RepositoryName: !Ref SourceRepo
                 BranchName: !Ref SourceBranch
           RunOrder: 10


### PR DESCRIPTION
Explicit turn-off of PollForSourceChanges when github token present, to prevent pipeline being triggered twice (i.e. via webhook and periodic polling).  See here for background: https://docs.aws.amazon.com/codepipeline/latest/userguide/pipelines-webhooks-create.html