### PR TITLE
ALB access restriction 

### DIFF
--- a/templates/assets/cloudformation/elb.yml
+++ b/templates/assets/cloudformation/elb.yml
@@ -211,7 +211,11 @@ Resources:
   Elb:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Scheme: !If [ IsElbInternal, "internal", "internet-facing" ]
+      Scheme:
+        Fn::If:
+        - IsElbInternal
+        - internal
+        - internet-facing
       Subnets:
         Fn::Split:
         - ","
@@ -219,14 +223,33 @@ Resources:
       Tags:
       - Key: Name
         Value: !Ref AWS::StackName
-      - !If [ShouldCreateElbAccessLogsS3Bucket, {"Key": 'mu:bucketpolicy', "Value": {"Ref": "ElbAccessLogsS3BucketPolicy"}}, !Ref 'AWS::NoValue']
+      - Fn::If:
+        - ShouldCreateElbAccessLogsS3Bucket
+        - Key: mu:bucketpolicy
+          Value:
+            Ref: ElbAccessLogsS3BucketPolicy
+        - Ref: AWS::NoValue
       SecurityGroups:
       - !Ref ElbSG
       LoadBalancerAttributes:
-      - Key: 'access_logs.s3.enabled'
-        Value: !If [ShouldCreateElbAccessLogsS3Bucket, 'true', 'false']
-      - !If [ShouldCreateElbAccessLogsS3Bucket, {"Key": 'access_logs.s3.prefix', "Value": {"Ref": "ElbAccessLogsS3Prefix"}}, !Ref 'AWS::NoValue']
-      - !If [ShouldCreateElbAccessLogsS3Bucket, {"Key": 'access_logs.s3.bucket', "Value": {"Ref": "ElbAccessLogsS3Bucket"}}, !Ref 'AWS::NoValue']
+      - Key: access_logs.s3.enabled
+        Value:
+          Fn::If:
+          - ShouldCreateElbAccessLogsS3Bucket
+          - "true"
+          - "false"
+      - Fn::If:
+        - ShouldCreateElbAccessLogsS3Bucket
+        - Key: access_logs.s3.prefix
+          Value:
+            Ref: ElbAccessLogsS3Prefix
+        - Ref: 'AWS::NoValue'
+      - Fn::If:
+        - ShouldCreateElbAccessLogsS3Bucket
+        - Key: access_logs.s3.bucket
+          Value:
+            Ref: ElbAccessLogsS3Bucket
+        - Ref: 'AWS::NoValue'
   ElbHttpListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:

--- a/templates/assets/cloudformation/elb.yml
+++ b/templates/assets/cloudformation/elb.yml
@@ -158,15 +158,24 @@ Resources:
       VpcId:
         Fn::ImportValue: !Sub ${VpcId}
       GroupDescription: ELB Security Group
-      SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: '80'
-        ToPort: '80'
-        CidrIp: 0.0.0.0/0
-      - IpProtocol: tcp
-        FromPort: '443'
-        ToPort: '443'
-        CidrIp: 0.0.0.0/0
+  Host2ELB80RuleIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      IpProtocol: tcp
+      FromPort: '80'
+      ToPort: '80'
+      CidrIp: 0.0.0.0/0
+      GroupId: 
+        Ref: ElbSG
+  Host2ELB443RuleIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      IpProtocol: tcp
+      FromPort: '443'
+      ToPort: '443'
+      CidrIp: 0.0.0.0/0
+      GroupId: 
+        Ref: ElbSG
   ELB2HostRuleIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:

--- a/templates/assets/cloudformation/elb.yml
+++ b/templates/assets/cloudformation/elb.yml
@@ -135,7 +135,7 @@ Resources:
               AWS:
                 Fn::Sub:
                   - "arn:${AWS::Partition}:iam::${ElbAccountId}:root"
-                  - ElbAccountId: !FindInMap [Regions, !Ref "AWS::Region", ElbAccountId]
+                  - ElbAccountId: !FindInMap [Regions, Ref: "AWS::Region", ElbAccountId]
             Action: s3:PutObject
             Resource: !Sub "arn:${AWS::Partition}:s3:::${ElbAccessLogsS3Bucket}/${ElbAccessLogsS3Prefix}/AWSLogs/${AWS::AccountId}/*"
   ServiceDiscoveryNamespace:
@@ -219,21 +219,14 @@ Resources:
       Tags:
       - Key: Name
         Value: !Ref AWS::StackName
+      - !If [ShouldCreateElbAccessLogsS3Bucket, {"Key": 'mu:bucketpolicy', "Value": {"Ref": "ElbAccessLogsS3BucketPolicy"}}, !Ref 'AWS::NoValue']
       SecurityGroups:
       - !Ref ElbSG
       LoadBalancerAttributes:
-      - Key: access_logs.s3.enabled
-        Value: "true"
-      - Key: access_logs.s3.bucket
-        Value:
-          !If
-            - ShouldCreateElbAccessLogsS3Bucket
-            - Fn::Select:
-                - 0
-                - [!Ref ElbAccessLogsS3Bucket, !Ref ElbAccessLogsS3BucketPolicy]
-            - !Ref ElbAccessLogsS3BucketName
-      - Key: access_logs.s3.prefix
-        Value: !Ref ElbAccessLogsS3Prefix
+      - Key: 'access_logs.s3.enabled'
+        Value: !If [ShouldCreateElbAccessLogsS3Bucket, 'true', 'false']
+      - !If [ShouldCreateElbAccessLogsS3Bucket, {"Key": 'access_logs.s3.prefix', "Value": {"Ref": "ElbAccessLogsS3Prefix"}}, !Ref 'AWS::NoValue']
+      - !If [ShouldCreateElbAccessLogsS3Bucket, {"Key": 'access_logs.s3.bucket', "Value": {"Ref": "ElbAccessLogsS3Bucket"}}, !Ref 'AWS::NoValue']
   ElbHttpListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:

--- a/templates/assets/cloudformation/elb.yml
+++ b/templates/assets/cloudformation/elb.yml
@@ -158,7 +158,7 @@ Resources:
       VpcId:
         Fn::ImportValue: !Sub ${VpcId}
       GroupDescription: ELB Security Group
-  Host2ELB80RuleIngress:
+  ELB80RuleIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       IpProtocol: tcp
@@ -167,7 +167,7 @@ Resources:
       CidrIp: 0.0.0.0/0
       GroupId: 
         Ref: ElbSG
-  Host2ELB443RuleIngress:
+  ELB443RuleIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       IpProtocol: tcp


### PR DESCRIPTION
By separating the ingress for port 80/443 to a resource it is possible to overwrite the CIDR with an extension or via the `templates` section in `mu.yml`. 

Along the way I defined a dependency between the access log property of the ALB and the bucket access policy.