### PR TITLE
ECS secrets

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -169,6 +169,7 @@ type Service struct {
 	AssignPublicIP       bool                   `yaml:"assignPublicIp,omitempty"`
 	Links                []string               `yaml:"links,omitempty"`
 	Environment          map[string]interface{} `yaml:"environment,omitempty"`
+	Secrets              map[string]interface{} `yaml:"secrets,omitempty"`
 	PathPatterns         []string               `yaml:"pathPatterns,omitempty"`
 	HostPatterns         []string               `yaml:"hostPatterns,omitempty"`
 	Priority             int                    `yaml:"priority,omitempty" validate:"max=50000"`

--- a/templates/assets/cloudformation/service-ecs.yml
+++ b/templates/assets/cloudformation/service-ecs.yml
@@ -355,6 +355,15 @@ Resources:
           - !Ref AWS::NoValue
         #DnsSearchDomains:
         #- Fn::ImportValue: !Sub ${ServiceDiscoveryName}
+        {{if .Secrets}}
+        Secrets:
+        {{with .Secrets}}
+          {{range $key, $val := .}}
+          - Name: {{$key}}
+            ValueFrom: !Sub {{$val}}
+          {{end}}
+        {{end}}
+        {{end}}
         Environment:
         {{with .Environment}}
           {{range $key, $val := .}}

--- a/templates/assets/cloudformation/service-iam.yml
+++ b/templates/assets/cloudformation/service-iam.yml
@@ -373,6 +373,9 @@ Resources:
             - logs:PutLogEvents
             - logs:DescribeLogGroups
             - logs:DescribeLogStreams
+            - ssm:GetParameters
+            - secretsmanager:GetSecretValue
+            - kms:Decrypt
             Resource: '*'
 
   EksPodRole:


### PR DESCRIPTION
Support for ECS Secrets (#399).

Example usage mu.yml:

```yml
service:
  secrets:
    API_TOKEN: arn:aws:secretsmanager:eu-central-1:999999999:secret:API_TOKEN-XXX
```

Tested on real AWS stack.