### PR TITLE
Fixing typo in deploy-database policy

### DIFF
--- a/templates/assets/cloudformation/common-iam.yml
+++ b/templates/assets/cloudformation/common-iam.yml
@@ -353,7 +353,7 @@ Resources:
             - rds:DeleteOptionGroup
             - rds:AddTagsToResource
             - rds:ListTagsToResource
-            - rds:RemoveTagsToResource
+            - rds:RemoveTagsFromResource
             - rds:AuthorizeDBSecurityGroupIngress
             - rds:RevokeDBSecurityGroupIngress
             Resource: '*'

--- a/templates/assets/cloudformation/common-iam.yml
+++ b/templates/assets/cloudformation/common-iam.yml
@@ -352,7 +352,7 @@ Resources:
             - rds:DeleteDBSubnetGroup
             - rds:DeleteOptionGroup
             - rds:AddTagsToResource
-            - rds:ListTagsToResource
+            - rds:ListTagsFromResource
             - rds:RemoveTagsFromResource
             - rds:AuthorizeDBSecurityGroupIngress
             - rds:RevokeDBSecurityGroupIngress

--- a/templates/assets/cloudformation/common-iam.yml
+++ b/templates/assets/cloudformation/common-iam.yml
@@ -352,7 +352,7 @@ Resources:
             - rds:DeleteDBSubnetGroup
             - rds:DeleteOptionGroup
             - rds:AddTagsToResource
-            - rds:ListTagsFromResource
+            - rds:ListTagsForResource
             - rds:RemoveTagsFromResource
             - rds:AuthorizeDBSecurityGroupIngress
             - rds:RevokeDBSecurityGroupIngress


### PR DESCRIPTION
https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonrds.html shows the list of Actions available, and rds:RemoveTagsToResource is meant to be rds:RemoveTagsFromResource