### PR TITLE
Add support for specifying ELB Cert ARN directly

### DIFF
--- a/templates/assets/cloudformation/elb.yml
+++ b/templates/assets/cloudformation/elb.yml
@@ -36,6 +36,10 @@ Parameters:
     Type: String
     Description: The identifier for the certificate to use for ELB. Leave blank to disable HTTPS
     Default: ''
+  ElbCertArn:
+    Type: String
+    Description: The ARN of the certificate to use for ELB. Leave blank to disable HTTPS
+    Default: ''    
   ElbAccessLogsS3BucketName:
     Type: String
     Description: The name of the S3 bucket to write ELB access logs into.
@@ -65,6 +69,11 @@ Conditions:
       - "Fn::Equals":
         - !Ref ElbCert
         - ''
+  HasElbCertArn:
+    "Fn::Not":
+      - "Fn::Equals":
+        - !Ref ElbCertArn
+        - ''        
   IsElbInternal:
     "Fn::Equals":
       - !Ref ElbInternal
@@ -268,7 +277,11 @@ Resources:
       - Type: forward
         TargetGroupArn: !Ref ElbDefaultTargetGroup
       Certificates:
-        - CertificateArn: !Sub "arn:${AWS::Partition}:acm:${AWS::Region}:${AWS::AccountId}:certificate/${ElbCert}"
+        - CertificateArn:
+          - Fn::If:
+            - HasElbCertArn
+              - !Sub "${ElbCertArn}"
+              - !Sub "arn:${AWS::Partition}:acm:${AWS::Region}:${AWS::AccountId}:certificate/${ElbCert}"
       Port: '443'
       Protocol: HTTPS
       SslPolicy: 'ELBSecurityPolicy-TLS-1-2-2017-01'

--- a/workflows/environment_upsert.go
+++ b/workflows/environment_upsert.go
@@ -251,7 +251,11 @@ func (workflow *environmentWorkflow) environmentElbUpserter(namespace string, en
 		stackParams["EnvironmentName"] = environment.Name
 
 		if environment.Loadbalancer.Certificate != "" {
-			stackParams["ElbCert"] = environment.Loadbalancer.Certificate
+			if strings.HasPrefix(environment.Loadbalancer.Certificate, "arn:") {
+				stackParams["ElbCertArn"] = environment.Loadbalancer.Certificate
+			} else {
+				stackParams["ElbCert"] = environment.Loadbalancer.Certificate
+			}
 		}
 
 		if environment.Loadbalancer.HostedZone != "" {


### PR DESCRIPTION
Adding support for specifying the ELB Cert ARN directly without adding a new attribute and just checking if the cert begins with "arn:". This may/may not be an acceptable approach but I don't know the codebase well enough to see if there's a better way. I tried to copy similar style to what I found "nearby" in both the Cloudformation and go code. Many thanks.

Closes #445